### PR TITLE
fix: check if tx exists

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oasisdex/spock-utils",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "AGPL-3.0-or-later",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/utils/src/extractors/rawEventDataExtractor.ts
+++ b/packages/utils/src/extractors/rawEventDataExtractor.ts
@@ -68,7 +68,13 @@ export async function extractRawLogs(
           return
         }
         const block = _block[0]
-        const storedTx = allStoredTxsByTxHash[log.transactionHash!][0]
+
+        const storedTxArray = allStoredTxsByTxHash[log.transactionHash!]
+        if (!storedTxArray) {
+          return
+        }
+        
+        const storedTx = storedTxArray[0]
 
         return {
           ...log,


### PR DESCRIPTION
Some of the extractors in oasis cache have failed with  ```{"name":"TypeError","message":"Cannot read property '0' of undefined","stack":"TypeError: Cannot read property '0' of undefined\n    at /app/node_modules/@oasisdex/spock-utils/src/extractors/rawEventDataExtractor.ts:70:68\n ```

hence an additional check has been added.
The source of the error is unknown.

Failed block : https://etherscan.io/block/19336045